### PR TITLE
RWA-154: Add permissions for each role to all tasks as configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ branches:
   only:
     - master
 
+jdk:
+  - openjdk11
+
 #services:
 #  - docker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG APP_INSIGHTS_AGENT_VERSION=2.5.1
 
 # Application image
 
-FROM hmctspublic.azurecr.io/base/java:openjdk-11-distroless-1.2
+FROM hmctspublic.azurecr.io/base/java:openjdk-11-distroless-1.4
 
 COPY lib/AI-Agent.xml /opt/app/
 COPY build/libs/wa-task-configuration-api.jar /opt/app/

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskconfigurationapi/ConfigureTaskTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskconfigurationapi/ConfigureTaskTest.java
@@ -70,6 +70,9 @@ public class ConfigureTaskTest extends BaseFunctionalTest {
             .body("securityClassification.value", is("PUBLIC"))
             .body("caseType.value", is("Asylum"))
             .body("title.value", is("task name"))
+            .body("tribunalCaseworker.value", is("Read,Refer,Own,Manage,Cancel"))
+            .body("seniorTribunalCaseworker.value", is("Read,Refer,Own,Manage,Cancel"))
+
         ;
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wataskconfigurationapi/controllers/ConfigurationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wataskconfigurationapi/controllers/ConfigurationControllerTest.java
@@ -14,9 +14,9 @@ import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.AddLocalVariableRequest;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaClient;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaValue;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableRequest;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableResult;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DmnRequest;
-import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.MapCaseDataDmnRequest;
-import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.MapCaseDataDmnResult;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.TaskResponse;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.ccd.CcdClient;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.idam.IdamApi;
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors.ConstantVariableExtractor.STATUS_VARIABLE_KEY;
+import static uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors.MapCaseDetailsService.MAP_CASE_DATA_DECISION_TABLE_NAME;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.controllers.util.CreatorObjectMapper.asJsonString;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaValue.jsonValue;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaValue.stringValue;
@@ -45,7 +46,7 @@ public class ConfigurationControllerTest {
 
     public static final String TASK_NAME = "taskName";
     @Autowired
-    private transient MockMvc mockMvc;
+    private MockMvc mockMvc;
 
     @MockBean
     private CamundaClient camundaClient;
@@ -72,7 +73,6 @@ public class ConfigurationControllerTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(asJsonString(new ConfigureTaskRequest(taskId)))
         ).andExpect(status().isOk()).andReturn();
-
 
         verify(camundaClient).addLocalVariablesToTask(taskId, new AddLocalVariableRequest(modifications));
     }
@@ -111,8 +111,12 @@ public class ConfigurationControllerTest {
                           + " }";
         when(ccdClient.getCase("Bearer " + userToken, serviceToken, ccdId)).thenReturn(caseData);
         when(camundaClient.mapCaseData(
-            "ia", "Asylum", new DmnRequest<>(new MapCaseDataDmnRequest(jsonValue(caseData))))
-        ).thenReturn(singletonList(new MapCaseDataDmnResult(stringValue("name1"), stringValue("value1"))));
+            MAP_CASE_DATA_DECISION_TABLE_NAME,
+            "ia",
+            "Asylum",
+            new DmnRequest<>(new DecisionTableRequest(jsonValue(caseData)))
+             )
+        ).thenReturn(singletonList(new DecisionTableResult(stringValue("name1"), stringValue("value1"))));
 
         HashMap<String, CamundaValue<String>> modifications = new HashMap<>();
         modifications.put("name1", stringValue("value1"));

--- a/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/MapCaseDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/MapCaseDetailsService.java
@@ -25,7 +25,9 @@ public class MapCaseDetailsService {
     private final CamundaClient camundaClient;
     private final PermissionsService permissionsService;
 
-    public MapCaseDetailsService(CcdDataService ccdDataService, CamundaClient camundaClient, PermissionsService permissionsService) {
+    public MapCaseDetailsService(CcdDataService ccdDataService,
+                                 CamundaClient camundaClient,
+                                 PermissionsService permissionsService) {
         this.ccdDataService = ccdDataService;
         this.camundaClient = camundaClient;
         this.permissionsService = permissionsService;

--- a/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/MapCaseDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/MapCaseDetailsService.java
@@ -4,27 +4,31 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaClient;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableRequest;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableResult;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DmnRequest;
-import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.MapCaseDataDmnRequest;
-import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.MapCaseDataDmnResult;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.ccd.CaseDetails;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.ccd.CcdDataService;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaValue.jsonValue;
 
 @Component
 public class MapCaseDetailsService {
+    public static final String MAP_CASE_DATA_DECISION_TABLE_NAME = "mapCaseData";
     private final CcdDataService ccdDataService;
     private final CamundaClient camundaClient;
+    private final PermissionsService permissionsService;
 
-    public MapCaseDetailsService(CcdDataService ccdDataService, CamundaClient camundaClient) {
+    public MapCaseDetailsService(CcdDataService ccdDataService, CamundaClient camundaClient, PermissionsService permissionsService) {
         this.ccdDataService = ccdDataService;
         this.camundaClient = camundaClient;
+        this.permissionsService = permissionsService;
     }
 
     public Map<String, Object> getMappedDetails(String ccdId) {
@@ -32,18 +36,28 @@ public class MapCaseDetailsService {
 
         try {
             CaseDetails caseDetails = new ObjectMapper().readValue(caseData, CaseDetails.class);
-            List<MapCaseDataDmnResult> mapCaseDataDmnResults = camundaClient.mapCaseData(
-                caseDetails.getJurisdiction(),
-                caseDetails.getCaseTypeId(),
+
+            String jurisdiction = caseDetails.getJurisdiction();
+            String caseType = caseDetails.getCaseTypeId();
+
+            List<DecisionTableResult> decisionTableResults = camundaClient.mapCaseData(
+                MAP_CASE_DATA_DECISION_TABLE_NAME,
+                jurisdiction,
+                caseType,
                 new DmnRequest<>(
-                    new MapCaseDataDmnRequest(jsonValue(caseData))
+                    new DecisionTableRequest(jsonValue(caseData))
                 )
             );
 
-            Map<String, Object> mappedCaseDetails = mapCaseDataDmnResults.stream().collect(toMap(
-                mapCaseDataDmnResult -> mapCaseDataDmnResult.getName().getValue(),
-                mapCaseDataDmnResult -> mapCaseDataDmnResult.getValue().getValue()
-            ));
+            List<DecisionTableResult> permissionsDmnResults =
+                permissionsService.getMappedDetails(jurisdiction, caseType, caseData);
+
+            Map<String, Object> mappedCaseDetails =
+                Stream.concat(decisionTableResults.stream(), permissionsDmnResults.stream())
+                    .collect(toMap(
+                        mapCaseDataDmnResult -> mapCaseDataDmnResult.getName().getValue(),
+                        mapCaseDataDmnResult -> mapCaseDataDmnResult.getValue().getValue()
+                    ));
 
             HashMap<String, Object> allMappedDetails = new HashMap<>(mappedCaseDetails);
             allMappedDetails.put("securityClassification", caseDetails.getSecurityClassification());

--- a/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/PermissionsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/PermissionsService.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors;
+
+import feign.FeignException;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaClient;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableRequest;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableResult;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DmnRequest;
+
+import java.util.List;
+
+import static uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaValue.jsonValue;
+
+@Component
+public class PermissionsService {
+    public static final String PERMISSION_DECISION_TABLE_NAME = "permissions";
+    private final CamundaClient camundaClient;
+
+    public PermissionsService(CamundaClient camundaClient) {
+        this.camundaClient = camundaClient;
+    }
+
+    public List<DecisionTableResult> getMappedDetails(String jurisdiction, String caseType, String caseData) {
+
+        try {
+            return camundaClient.mapCaseData(
+                PERMISSION_DECISION_TABLE_NAME,
+                jurisdiction,
+                caseType,
+                new DmnRequest<>(
+                    new DecisionTableRequest(jsonValue(caseData))
+                )
+            );
+
+        } catch (FeignException e) {
+            throw new IllegalStateException(
+                "Could not evaluate from decision table [" + PERMISSION_DECISION_TABLE_NAME + "]",
+                e
+            );
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/thirdparty/camunda/CamundaClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/thirdparty/camunda/CamundaClient.java
@@ -15,13 +15,14 @@ import java.util.Map;
 )
 public interface CamundaClient {
     @PostMapping(
-        value = "/decision-definition/key/mapCaseData_{jurisdiction}_{caseType}/evaluate",
+        value = "/decision-definition/key/{decisionTableName}_{jurisdiction}_{caseType}/evaluate",
         produces = MediaType.APPLICATION_JSON_VALUE
     )
-    List<MapCaseDataDmnResult> mapCaseData(
+    List<DecisionTableResult> mapCaseData(
+        @PathVariable("decisionTableName") String decisionTableName,
         @PathVariable("jurisdiction") String jurisdiction,
         @PathVariable("caseType") String caseType,
-        DmnRequest<MapCaseDataDmnRequest> requestParameters
+        DmnRequest<DecisionTableRequest> requestParameters
     );
 
     @PostMapping(value = "/task/{id}/localVariables", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/thirdparty/camunda/DecisionTableRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/thirdparty/camunda/DecisionTableRequest.java
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
-public class MapCaseDataDmnRequest {
+public class DecisionTableRequest {
 
     private final CamundaValue<String> caseJson;
 
-    public MapCaseDataDmnRequest(CamundaValue<String> caseJson) {
+    public DecisionTableRequest(CamundaValue<String> caseJson) {
         this.caseJson = caseJson;
     }
 
@@ -25,7 +25,7 @@ public class MapCaseDataDmnRequest {
         if (object == null || getClass() != object.getClass()) {
             return false;
         }
-        MapCaseDataDmnRequest that = (MapCaseDataDmnRequest) object;
+        DecisionTableRequest that = (DecisionTableRequest) object;
         return Objects.equals(caseJson, that.caseJson);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/thirdparty/camunda/DecisionTableResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/thirdparty/camunda/DecisionTableResult.java
@@ -2,14 +2,14 @@ package uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda;
 
 import java.util.Objects;
 
-public class MapCaseDataDmnResult {
+public class DecisionTableResult {
     private CamundaValue<String> name;
     private CamundaValue<String> value;
 
-    private MapCaseDataDmnResult() {
+    private DecisionTableResult() {
     }
 
-    public MapCaseDataDmnResult(CamundaValue<String> name, CamundaValue<String> value) {
+    public DecisionTableResult(CamundaValue<String> name, CamundaValue<String> value) {
         this.name = name;
         this.value = value;
     }
@@ -30,7 +30,7 @@ public class MapCaseDataDmnResult {
         if (object == null || getClass() != object.getClass()) {
             return false;
         }
-        MapCaseDataDmnResult that = (MapCaseDataDmnResult) object;
+        DecisionTableResult that = (DecisionTableResult) object;
         return Objects.equals(name, that.name)
                && Objects.equals(value, that.value);
     }

--- a/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/PojoTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/PojoTest.java
@@ -12,9 +12,9 @@ import pl.pojo.tester.internal.utils.ThoroughFieldPermutator;
 import uk.gov.hmcts.reform.wataskconfigurationapi.controllers.ConfigureTaskRequest;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.AddLocalVariableRequest;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaValue;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableRequest;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableResult;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DmnRequest;
-import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.MapCaseDataDmnRequest;
-import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.MapCaseDataDmnResult;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.TaskResponse;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.ccd.CaseDetails;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.idam.Token;
@@ -39,9 +39,9 @@ class PojoTest {
 
     private final Class[] classesToTest = {
         ConfigureTaskRequest.class,
-        MapCaseDataDmnRequest.class,
+        DecisionTableRequest.class,
         DmnRequest.class,
-        MapCaseDataDmnResult.class,
+        DecisionTableResult.class,
         CamundaValue.class,
         AddLocalVariableRequest.class,
         TaskResponse.class,
@@ -52,7 +52,7 @@ class PojoTest {
     // Cannot test equals for generic classes
     private final Class[] ignoreEquals = {
         DmnRequest.class,
-        MapCaseDataDmnRequest.class,
+        DecisionTableRequest.class,
         CamundaValue.class
     };
     private final ObjectGenerator objectGenerator = new ObjectGenerator(

--- a/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/CamundaProcessVariableExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/CamundaProcessVariableExtractorTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractor;
+package uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/ConstantVariableExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/ConstantVariableExtractorTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractor;
+package uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/MapCaseDetailsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/MapCaseDetailsServiceTest.java
@@ -1,12 +1,16 @@
-package uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractor;
+package uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors.MapCaseDetailsService;
+import uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors.PermissionsService;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaClient;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableRequest;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableResult;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DmnRequest;
-import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.MapCaseDataDmnRequest;
-import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.MapCaseDataDmnResult;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.ccd.CcdDataService;
 
 import java.util.HashMap;
@@ -20,19 +24,19 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors.MapCaseDetailsService.MAP_CASE_DATA_DECISION_TABLE_NAME;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaValue.jsonValue;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaValue.stringValue;
 
+@ExtendWith(MockitoExtension.class)
 class MapCaseDetailsServiceTest {
 
+    @Mock
     private CamundaClient camundaClient;
+    @Mock
     private CcdDataService ccdDataService;
-
-    @BeforeEach
-    void setUp() {
-        camundaClient = mock(CamundaClient.class);
-        ccdDataService = mock(CcdDataService.class);
-    }
+    @Mock
+    private PermissionsService permissionsService;
 
     @Test
     void doesNotHaveAnyFieldsToMap() {
@@ -44,14 +48,25 @@ class MapCaseDetailsServiceTest {
                          + "\"data\": {}"
                          + "}";
         when(ccdDataService.getCaseData(someCcdId)).thenReturn(ccdData);
+        when(permissionsService.getMappedDetails("ia", "Asylum", ccdData))
+            .thenReturn(asList(
+                new DecisionTableResult(stringValue("tribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel")),
+                new DecisionTableResult(stringValue("seniorTribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel"))
+            ));
         when(camundaClient.mapCaseData(
-            "ia", "Asylum", new DmnRequest<>(new MapCaseDataDmnRequest(stringValue(ccdData))))
+            MAP_CASE_DATA_DECISION_TABLE_NAME,
+            "ia",
+            "Asylum",
+            new DmnRequest<>(new DecisionTableRequest(jsonValue(ccdData)))
+             )
         ).thenReturn(emptyList());
 
         HashMap<String, Object> expectedMappedData = new HashMap<>();
+        expectedMappedData.put("tribunalCaseworker", "Read,Refer,Own,Manage,Cancel");
+        expectedMappedData.put("seniorTribunalCaseworker", "Read,Refer,Own,Manage,Cancel");
         expectedMappedData.put("securityClassification", "PUBLIC");
         expectedMappedData.put("caseType", "Asylum");
-        Map<String, Object> mappedData = new MapCaseDetailsService(ccdDataService, camundaClient)
+        Map<String, Object> mappedData = new MapCaseDetailsService(ccdDataService, camundaClient, permissionsService)
             .getMappedDetails(someCcdId);
 
         assertThat(mappedData, is(expectedMappedData));
@@ -66,7 +81,11 @@ class MapCaseDetailsServiceTest {
                 String ccdData = "not valid json";
                 when(ccdDataService.getCaseData(someCcdId)).thenReturn(ccdData);
 
-                Map<String, Object> mappedData = new MapCaseDetailsService(ccdDataService, camundaClient)
+                Map<String, Object> mappedData = new MapCaseDetailsService(
+                    ccdDataService,
+                    camundaClient,
+                    permissionsService
+                )
                     .getMappedDetails(someCcdId);
 
                 assertThat(mappedData, is(emptyMap()));
@@ -84,9 +103,16 @@ class MapCaseDetailsServiceTest {
                          + "\"data\": {}"
                          + "}";
         when(ccdDataService.getCaseData(someCcdId)).thenReturn(ccdData);
-        when(camundaClient.mapCaseData("ia", "Asylum", new DmnRequest<>(new MapCaseDataDmnRequest(jsonValue(ccdData)))))
-            .thenReturn(asList(new MapCaseDataDmnResult(stringValue("name1"), stringValue("value1")),
-                               new MapCaseDataDmnResult(stringValue("name2"), stringValue("value2"))));
+        when(camundaClient.mapCaseData(
+            MAP_CASE_DATA_DECISION_TABLE_NAME,
+            "ia",
+            "Asylum",
+            new DmnRequest<>(new DecisionTableRequest(jsonValue(ccdData)))
+        ))
+            .thenReturn(asList(
+                new DecisionTableResult(stringValue("name1"), stringValue("value1")),
+                new DecisionTableResult(stringValue("name2"), stringValue("value2"))
+            ));
 
         HashMap<String, Object> expectedMappedData = new HashMap<>();
         expectedMappedData.put("name1", "value1");
@@ -94,8 +120,10 @@ class MapCaseDetailsServiceTest {
         expectedMappedData.put("securityClassification", "PUBLIC");
         expectedMappedData.put("caseType", "Asylum");
 
-        Map<String, Object> mappedData = new MapCaseDetailsService(ccdDataService,
-                                                                   camundaClient
+        Map<String, Object> mappedData = new MapCaseDetailsService(
+            ccdDataService,
+            camundaClient,
+            permissionsService
         ).getMappedDetails(someCcdId);
 
         assertThat(mappedData, is(expectedMappedData));

--- a/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/MapCaseDetailsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/MapCaseDetailsServiceTest.java
@@ -1,12 +1,9 @@
 package uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors.MapCaseDetailsService;
-import uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors.PermissionsService;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaClient;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableRequest;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableResult;
@@ -22,7 +19,6 @@ import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors.MapCaseDetailsService.MAP_CASE_DATA_DECISION_TABLE_NAME;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaValue.jsonValue;
@@ -50,8 +46,10 @@ class MapCaseDetailsServiceTest {
         when(ccdDataService.getCaseData(someCcdId)).thenReturn(ccdData);
         when(permissionsService.getMappedDetails("ia", "Asylum", ccdData))
             .thenReturn(asList(
-                new DecisionTableResult(stringValue("tribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel")),
-                new DecisionTableResult(stringValue("seniorTribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel"))
+                new DecisionTableResult(
+                    stringValue("tribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel")),
+                new DecisionTableResult(
+                    stringValue("seniorTribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel"))
             ));
         when(camundaClient.mapCaseData(
             MAP_CASE_DATA_DECISION_TABLE_NAME,

--- a/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/PermissionsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/PermissionsServiceTest.java
@@ -6,20 +6,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.web.server.ServerErrorException;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaClient;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableRequest;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableResult;
 import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DmnRequest;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors.PermissionsService.PERMISSION_DECISION_TABLE_NAME;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaValue.jsonValue;
@@ -53,16 +50,20 @@ class PermissionsServiceTest {
             new DmnRequest<>(new DecisionTableRequest(jsonValue(ccdData)))
         ))
             .thenReturn(asList(
-                new DecisionTableResult(stringValue("tribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel")),
-                new DecisionTableResult(stringValue("seniorTribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel"))
+                new DecisionTableResult(
+                    stringValue("tribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel")),
+                new DecisionTableResult(
+                    stringValue("seniorTribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel"))
             ));
 
         List<DecisionTableResult> response = permissionsService.getMappedDetails("ia", "Asylum", ccdData);
 
         assertThat(response.size(), is(2));
         assertThat(response, is(asList(
-            new DecisionTableResult(stringValue("tribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel")),
-            new DecisionTableResult(stringValue("seniorTribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel"))
+            new DecisionTableResult(
+                stringValue("tribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel")),
+            new DecisionTableResult(
+                stringValue("seniorTribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel"))
         )));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/PermissionsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/PermissionsServiceTest.java
@@ -1,0 +1,91 @@
+package uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors;
+
+import feign.FeignException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ServerErrorException;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaClient;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableRequest;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DecisionTableResult;
+import uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.DmnRequest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors.PermissionsService.PERMISSION_DECISION_TABLE_NAME;
+import static uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaValue.jsonValue;
+import static uk.gov.hmcts.reform.wataskconfigurationapi.thirdparty.camunda.CamundaValue.stringValue;
+
+@ExtendWith(MockitoExtension.class)
+class PermissionsServiceTest {
+
+    PermissionsService permissionsService;
+    @Mock
+    private CamundaClient camundaClient;
+
+    @BeforeEach
+    void setUp() {
+        permissionsService = new PermissionsService(camundaClient);
+    }
+
+    @Test
+    void should_succeed_and_return_a_list_of_permissions() {
+        String ccdData = "{"
+                         + "\"jurisdiction\": \"ia\","
+                         + "\"case_type_id\": \"Asylum\","
+                         + "\"security_classification\": \"PUBLIC\","
+                         + "\"data\": {}"
+                         + "}";
+
+        when(camundaClient.mapCaseData(
+            PERMISSION_DECISION_TABLE_NAME,
+            "ia",
+            "Asylum",
+            new DmnRequest<>(new DecisionTableRequest(jsonValue(ccdData)))
+        ))
+            .thenReturn(asList(
+                new DecisionTableResult(stringValue("tribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel")),
+                new DecisionTableResult(stringValue("seniorTribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel"))
+            ));
+
+        List<DecisionTableResult> response = permissionsService.getMappedDetails("ia", "Asylum", ccdData);
+
+        assertThat(response.size(), is(2));
+        assertThat(response, is(asList(
+            new DecisionTableResult(stringValue("tribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel")),
+            new DecisionTableResult(stringValue("seniorTribunalCaseworker"), stringValue("Read,Refer,Own,Manage,Cancel"))
+        )));
+    }
+
+
+    @Test
+    void should_throw_illegal_state_exception_when_feign_exception_is_caught() {
+        String ccdData = "{"
+                         + "\"jurisdiction\": \"ia\","
+                         + "\"case_type_id\": \"Asylum\","
+                         + "\"security_classification\": \"PUBLIC\","
+                         + "\"data\": {}"
+                         + "}";
+
+        when(camundaClient.mapCaseData(
+            PERMISSION_DECISION_TABLE_NAME,
+            "ia",
+            "Asylum",
+            new DmnRequest<>(new DecisionTableRequest(jsonValue(ccdData)))
+        )).thenThrow(FeignException.class);
+
+        assertThatThrownBy(() -> permissionsService.getMappedDetails("ia", "Asylum", ccdData))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Could not evaluate from decision table [permissions]")
+            .hasCauseInstanceOf(FeignException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/SystemConfiguredVariableExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/ccdmapping/variableextractors/SystemConfiguredVariableExtractorTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractor;
+package uk.gov.hmcts.reform.wataskconfigurationapi.ccdmapping.variableextractors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-154

### Change description ###

Added Permission decision table and service that calls camunda to evaluate and add the fields from the dmn table Refactoring dmn endpoint so it could be re-used. Minor package refactoring.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
