### PR TITLE
Correcting roles naming convention.

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/wataskconfigurationapi/ConfigureTaskTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wataskconfigurationapi/ConfigureTaskTest.java
@@ -71,8 +71,8 @@ public class ConfigureTaskTest extends BaseFunctionalTest {
             .body("securityClassification.value", is("PUBLIC"))
             .body("caseType.value", is("Asylum"))
             .body("title.value", is("task name"))
-            .body("tribunalCaseworker.value", is("Read,Refer,Own,Manage,Cancel"))
-            .body("seniorTribunalCaseworker.value", is("Read,Refer,Own,Manage,Cancel"))
+            .body("tribunal-caseworker.value", is("Read,Refer,Own,Manage,Cancel"))
+            .body("senior-tribunal-caseworker.value", is("Read,Refer,Own,Manage,Cancel"))
 
         ;
     }


### PR DESCRIPTION
### Change description ###

Correcting roles naming convention.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
