### PR TITLE
RWA-463: Performance Improvement: Make idam use the api url directly 

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -37,6 +37,7 @@ withPipeline(type, product, component) {
   disableLegacyDeployment()
 
   env.IDAM_URL = "https://idam-api.aat.platform.hmcts.net"
+  env.IDAM_API_URL = "https://idam-api.aat.platform.hmcts.net"
   env.S2S_URL = "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
   env.CAMUNDA_URL = "http://camunda-api-aat.service.core-compute-aat.internal/engine-rest"
   env.CCD_URL = "http://ccd-data-store-api-aat.service.core-compute-aat.internal"

--- a/charts/wa-task-configuration-api/Chart.yaml
+++ b/charts/wa-task-configuration-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for wa-task-configuration-api App
 name: wa-task-configuration-api
 home: https://github.com/hmcts/wa-task-configuration-api
-version: 0.0.9
+version: 0.0.10
 maintainers:
   - name: HMCTS wa team
 dependencies:

--- a/charts/wa-task-configuration-api/values.yaml
+++ b/charts/wa-task-configuration-api/values.yaml
@@ -7,6 +7,7 @@ java:
     CAMUNDA_URL: "http://camunda-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/engine-rest"
     ROLE_ASSIGNMENT_URL: "http://am-role-assignment-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     IDAM_URL: "https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net"
+    IDAM_API_URL: "https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net"
     S2S_URL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     CCD_URL: "http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
   keyVaults:

--- a/src/contractTest/resources/application.properties
+++ b/src/contractTest/resources/application.properties
@@ -1,4 +1,5 @@
 idam.baseUrl=http://localhost:8892
+idam.api.baseUrl=http://localhost:8892
 idam.redirectUrl=${IA_IDAM_REDIRECT_URI:http://localhost:8892/oauth2/callback}
 idam.scope="openid profile roles"
 idam.s2s-auth.url=${S2S_URL:http://127.0.0.1:4502}

--- a/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/clients/IdamServiceApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/wataskconfigurationapi/clients/IdamServiceApi.java
@@ -17,7 +17,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @FeignClient(
     name = "idam-api",
-    url = "${idam.baseUrl}",
+    url = "${idam.api.baseUrl}",
     configuration = FeignConfiguration.class
 )
 public interface IdamServiceApi {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,6 +35,7 @@ auth:
 idam:
   baseUrl: ${IDAM_URL:http://sidam-api}
   redirectUrl: ${IA_IDAM_REDIRECT_URI:http://localhost:3002/oauth2/callback}
+  scope: "openid profile roles"
   s2s-auth:
     url: ${S2S_URL:http://service-auth-provider-api}
     secret: ${S2S_SECRET_TASK_CONFIGURATION_API:AAAAAAAAAAAAAAAC}
@@ -42,7 +43,8 @@ idam:
   system:
     username: ${WA_SYSTEM_USERNAME:some_user@hmcts.net}
     password: ${WA_SYSTEM_PASSWORD:password}
-  scope: "openid profile roles"
+  api:
+    baseUrl: ${IDAM_API_URL:http://sidam-api}
 
 spring:
   application:


### PR DESCRIPTION
### JIRA link (if applicable) ###

I noticed we sometimes call idam endpoints through the idam-web-public url this is wrong and we should call those endpoints through the idam api instead. 

The reason for this is that it seems that if you call the web public url it proxies your request into the api making 2 calls with 400 ms  delay. 

We could avoid that second call by calling the idam-api directly and cut the time the request takes by half.

### Change description ###

https://tools.hmcts.net/jira/browse/RWA-463

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
