### PR TITLE
Fix CVE-2021-29425

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -239,6 +239,8 @@ dependencyManagement {
       entry 'guava'
     }
     dependency group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
+
+    dependency group: 'commons-io', name: 'commons-io', version: '2.8.0'
   }
 }
 
@@ -291,7 +293,7 @@ dependencies {
 
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.43'
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.43'
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.0.2'
+  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '2.2.5.RELEASE'
 
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.1.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -291,7 +291,7 @@ dependencies {
 
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.43'
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.43'
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '2.2.5.RELEASE'
+  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.0.2'
 
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.1.2'
 

--- a/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/services/CamundaServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/services/CamundaServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.wataskconfigurationapi.services;
 
-import com.microsoft.applicationinsights.core.dependencies.google.gson.Gson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,8 +13,6 @@ import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.AddLoc
 import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.AssigneeRequest;
 import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.CamundaTask;
 import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.CamundaValue;
-import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.DecisionTableRequest;
-import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.DmnRequest;
 import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.enums.TaskState;
 import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.configuration.TaskToConfigure;
 
@@ -27,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.CamundaValue.jsonValue;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.enums.CamundaVariableDefinition.CASE_ID;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.enums.CamundaVariableDefinition.TASK_STATE;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.enums.TaskState.UNCONFIGURED;
@@ -85,27 +81,6 @@ class CamundaServiceTest {
         assertEquals(actualCamundaTask.getName(), camundaTask.getName());
         assertEquals(actualCamundaTask.getId(), camundaTask.getId());
         assertEquals(actualCamundaTask.getProcessInstanceId(), camundaTask.getProcessInstanceId());
-    }
-
-    @Test
-    void should_get_task2() {
-
-        String caseDate = "{\n"
-                          + "  \"id\": \"123456789\",\n"
-                          + "  \"data\": {\n"
-                          + "    \"caseManagementLocation\": {\n"
-                          + "      \"region\": \"1\",\n"
-                          + "      \"baseLocation\": \"1123455\"\n"
-                          + "    },\n"
-                          + "    \"staffLocation\": \"Newcastle\",\n"
-                          + "    \"appealType\": \"refusalOfHumanRights\",\n"
-                          + "    \"appellantGivenNames\": \"John\",\n"
-                          + "    \"appellantFamilyName\": \"Doe\"\n"
-                          + "  }\n"
-                          + "}";
-        System.out.println(new Gson().toJson(new DmnRequest<>(
-            new DecisionTableRequest(jsonValue(caseDate))
-        )));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/services/CamundaServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wataskconfigurationapi/services/CamundaServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.wataskconfigurationapi.services;
 
+import com.microsoft.applicationinsights.core.dependencies.google.gson.Gson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,6 +14,8 @@ import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.AddLoc
 import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.AssigneeRequest;
 import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.CamundaTask;
 import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.CamundaValue;
+import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.DecisionTableRequest;
+import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.DmnRequest;
 import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.enums.TaskState;
 import uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.configuration.TaskToConfigure;
 
@@ -24,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.CamundaValue.jsonValue;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.enums.CamundaVariableDefinition.CASE_ID;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.enums.CamundaVariableDefinition.TASK_STATE;
 import static uk.gov.hmcts.reform.wataskconfigurationapi.domain.entities.camunda.enums.TaskState.UNCONFIGURED;
@@ -81,6 +85,27 @@ class CamundaServiceTest {
         assertEquals(actualCamundaTask.getName(), camundaTask.getName());
         assertEquals(actualCamundaTask.getId(), camundaTask.getId());
         assertEquals(actualCamundaTask.getProcessInstanceId(), camundaTask.getProcessInstanceId());
+    }
+
+    @Test
+    void should_get_task2() {
+
+        String caseDate = "{\n"
+                          + "  \"id\": \"123456789\",\n"
+                          + "  \"data\": {\n"
+                          + "    \"caseManagementLocation\": {\n"
+                          + "      \"region\": \"1\",\n"
+                          + "      \"baseLocation\": \"1123455\"\n"
+                          + "    },\n"
+                          + "    \"staffLocation\": \"Newcastle\",\n"
+                          + "    \"appealType\": \"refusalOfHumanRights\",\n"
+                          + "    \"appellantGivenNames\": \"John\",\n"
+                          + "    \"appellantFamilyName\": \"Doe\"\n"
+                          + "  }\n"
+                          + "}";
+        System.out.println(new Gson().toJson(new DmnRequest<>(
+            new DecisionTableRequest(jsonValue(caseDate))
+        )));
     }
 
     @Test


### PR DESCRIPTION

### JIRA link (if applicable) ###



### Change description ###

Fix CVE-2021-29425, Update spring-cloud-starter-openfeign to latest version

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
